### PR TITLE
Added Sections to Collections Package

### DIFF
--- a/Collections/Book.java
+++ b/Collections/Book.java
@@ -7,7 +7,7 @@ public class Book extends LibraryCollection {
     // In memory storage of all books in the collection
     public static HashMap<char[], Book> bookCollection = new HashMap<char[], Book>();
 
-    Book(char[] ISBN, byte section) throws InvalidIdentifierSizeException {
+    public Book(char[] ISBN, SectionCode section) throws InvalidIdentifierSizeException {
         super(ISBN, section);
         bookCollection.put(identifier, this);
     }

--- a/Collections/DVD.java
+++ b/Collections/DVD.java
@@ -7,7 +7,7 @@ public class DVD extends LibraryCollection {
     // In memory storage of all of the DVDs in the collection
     public static HashMap<char[], DVD> dvdCollection = new HashMap<char[], DVD>();
 
-    DVD(char[] DOI, byte section) throws InvalidIdentifierSizeException {
+    public DVD(char[] DOI, SectionCode section) throws InvalidIdentifierSizeException {
         super(DOI, section);
         dvdCollection.put(identifier, this);
     }

--- a/Collections/Journal.java
+++ b/Collections/Journal.java
@@ -7,7 +7,7 @@ public class Journal extends LibraryCollection {
     // In memory storage of all of the journals in the collection
     public static HashMap<char[], Journal> journalCollection = new HashMap<char[], Journal>();
 
-    Journal(char[] ISSN, byte section) throws InvalidIdentifierSizeException {
+    public Journal(char[] ISSN, SectionCode section) throws InvalidIdentifierSizeException {
         super(ISSN, section);
         journalCollection.put(identifier, this);
     }

--- a/Collections/LibraryCollection.java
+++ b/Collections/LibraryCollection.java
@@ -9,15 +9,22 @@ The abstract class that all pieces of media inherit from
 Basic information relating to their accessibility, location, and identifiers are avaiable here
 */
 public abstract class LibraryCollection {
+    public static enum SectionCode {
+        ARTS,
+        SCIENCES,
+        NEWSPAPER,
+        LAW,
+    };
+
     // Hashmap to store all members of the collection, because databases are cringe
     public static HashMap<char[], LibraryCollection> collection = new HashMap<char[], LibraryCollection>();
 
     protected char[] identifier;                // The ISBN or ISSN of a book
-    private byte section;                       // The numeric code corresponding to the section the media belongs to
+    private SectionCode section;                       // The numeric code corresponding to the section the media belongs to
     private boolean isCheckedOut = false;       // Is the piece of media already checked out?
 
     // No default constructor, too much headache
-    LibraryCollection(char[] id, byte section) throws InvalidIdentifierSizeException{
+    public LibraryCollection(char[] id, SectionCode section) throws InvalidIdentifierSizeException{
         if (id.length != 6) {
             throw new InvalidIdentifierSizeException("The size of the input was " + id.length + ", when it needed to be of size 6");
         } else {
@@ -33,7 +40,7 @@ public abstract class LibraryCollection {
     }
 
     // Returns the numeric representation of the section 
-    public byte getSection() {
+    public SectionCode getSection() {
         return section;
     }
 

--- a/Collections/Newspaper.java
+++ b/Collections/Newspaper.java
@@ -7,8 +7,8 @@ public class Newspaper extends LibraryCollection {
     // In memory storage of all of the newspapers in the collection
     public static HashMap<char[], Newspaper> newspaperCollection = new HashMap<char[], Newspaper>();
 
-    Newspaper(char[] ISSN, byte section) throws InvalidIdentifierSizeException {
-        super(ISSN, section);
+    public Newspaper(char[] ISSN, byte section) throws InvalidIdentifierSizeException {
+        super(ISSN, LibraryCollection.SectionCode.NEWSPAPER);
         newspaperCollection.put(identifier, this);
     }
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # Class Project for CMP_SC 3330
 
 ## Rubric Feature List
- - [ ] LibraryCollection with Books, Newspapers, DVDs, and Journals
-	 - [ ] These can be shelved in sections: Arts, Sciences, Newspapers, and Law
-	 - [ ] All Collections have alphanumeric 6 character long UID
-	 - [ ] Books and DVDs have ISBN numbers
-	 - [ ] Newspapers and Jornals have ISSN numbers
+ - [X] LibraryCollection with Books, Newspapers, DVDs, and Journals
+	 - [X] These can be shelved in sections: Arts, Sciences, Newspapers, and Law
+	 - [X] All Collections have alphanumeric 6 character long UID
+	 - [X] Books and DVDs have ISBN numbers
+	 - [X] Newspapers and Jornals have ISSN numbers
  - [ ] Employee Classes
 	 - [ ] Librarians: manage collections, help customers with resources, and manage memberships
 	 - [ ] Technicians: sort returned books and re-shelve them
  - [ ] Member Classes
-	 - [ ] All members have a UID
+	 - [X] All members have a UID
 	 - [ ] Can borrow no more than 5 materials
-	 - [ ] A Professor supervises multiple students
-	 - [ ] A Student has one prof as advisor
-	 - [ ] External is people unaffiliated with the University
+	 - [X] A Professor supervises multiple students
+	 - [X] A Student has one prof as advisor
+	 - [X] External is people unaffiliated with the University
  - [ ] Member Deadlines
 	 - [ ] Each material is kept max 2 weeks
 	 - [ ] An email is sent on the 12th days as a reminder


### PR DESCRIPTION
Section Codes are now encoded in a static enum in LibraryCollections class.  This should allow for simpler referencing to sections down the line.

Also increased the visibility of the class constructors so that objects can be created in other packages.